### PR TITLE
Add dynamic process list from SQL Server

### DIFF
--- a/run_spider.py
+++ b/run_spider.py
@@ -1,0 +1,26 @@
+import json
+import tempfile
+from scrapy.crawler import CrawlerProcess
+from scrapy.utils.project import get_project_settings
+
+from trf2.db_utils import fetch_process_numbers
+from trf2.spiders.eproc_spider import EprocTrf2Spider
+
+
+def main():
+    processos = fetch_process_numbers()
+    if not processos:
+        print("Nenhum processo encontrado para processamento.")
+        return
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".json", mode="w") as tmp:
+        json.dump(processos, tmp, ensure_ascii=False)
+        print(f"Lista de processos salva em {tmp.name}")
+
+    process = CrawlerProcess(get_project_settings())
+    process.crawl(EprocTrf2Spider, processos=processos)
+    process.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/trf2/db_utils.py
+++ b/trf2/db_utils.py
@@ -1,0 +1,59 @@
+import os
+from datetime import datetime, timedelta
+import pandas as pd
+from sqlalchemy import create_engine, text
+# from airflow.hooks.base import BaseHook  # Uncomment when running in Airflow
+
+
+def fetch_process_numbers():
+    """Return list of process numbers from SQL Server."""
+    try:
+        # --- Airflow implementation ---
+        # connection = BaseHook.get_connection("sqlserver_conn")
+        # user = connection.login
+        # password = connection.password
+        # server = connection.host
+        # database = connection.schema
+        # connection_string = (
+        #     f"mssql+pyodbc://{user}:{password}@{server}:1433/{database}"
+        #     "?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=yes&TrustServerCertificate=yes&Connection Timeout=60&MARS_Connection=yes"
+        # )
+
+        # --- Local implementation ---
+        user = os.getenv("SQLSERVER_USER")
+        password = os.getenv("SQLSERVER_PASSWORD")
+        server = os.getenv("SQLSERVER_HOST", "localhost")
+        database = os.getenv("SQLSERVER_DB")
+        connection_string = (
+            f"mssql+pyodbc://{user}:{password}@{server}:1433/{database}"
+            "?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=yes&TrustServerCertificate=yes&Connection Timeout=60&MARS_Connection=yes"
+        )
+
+        engine = create_engine(
+            connection_string,
+            pool_size=5,
+            max_overflow=10,
+            pool_timeout=30,
+            pool_recycle=1800,
+        )
+
+        data_anterior = (datetime.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+        query = """
+            SELECT numero_processo
+            FROM dbo.cnjComunicacoesProcessuais c
+            WHERE link_documento LIKE 'https://pje1g.%' AND tribunal = 'TRF3' AND data_disponibilizacao = :data_disponibilizacao
+               AND NOT EXISTS (
+                  SELECT 1
+                  FROM pje.Processos p
+                  WHERE p.cnj = c.numero_processo
+              );
+        """
+
+        with engine.connect() as conn:
+            result = conn.execute(text(query), {"data_disponibilizacao": data_anterior})
+            df = pd.DataFrame(result.fetchall(), columns=result.keys())
+
+        return df["numero_processo"].dropna().unique().tolist()
+
+    except Exception as e:
+        raise Exception(f"Erro ao extrair numero_processo: {e}")


### PR DESCRIPTION
## Summary
- add helper to query SQL Server for process numbers with optional Airflow code
- allow spider to accept a list of process numbers instead of a single one
- include small runner script to fetch processes and run spider

## Testing
- `python -m py_compile run_spider.py trf2/db_utils.py trf2/spiders/eproc_spider.py`

------
https://chatgpt.com/codex/tasks/task_b_685036adec54832e9c5efc84a874e341