### PR TITLE
Enable Webshare proxy rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Example environment configuration for TRF2 scraper
+WEBSHARE_API_KEY=your_api_key_here
+# Optional custom URL if different from default
+#WEBSHARE_PROXY_URL=https://proxy.webshare.io/api/v2/proxy/list/?mode=direct&page=1&page_size=500
+
+# Existing variables used elsewhere
+SQLSERVER_USER=
+SQLSERVER_PASSWORD=
+SQLSERVER_HOST=
+SQLSERVER_DB=
+AZURE_STORAGE_ACCOUNT_NAME=
+AZURE_STORAGE_ACCOUNT_KEY=

--- a/trf2/proxy_utils.py
+++ b/trf2/proxy_utils.py
@@ -1,0 +1,34 @@
+import os
+import logging
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+
+API_URL_DEFAULT = "https://proxy.webshare.io/api/v2/proxy/list/?mode=direct&page=1&page_size=500"
+API_URL = os.getenv("WEBSHARE_PROXY_URL", API_URL_DEFAULT)
+API_KEY = os.getenv("WEBSHARE_API_KEY")
+
+
+def carregar_proxies(api_url: str = API_URL, api_key: str = API_KEY):
+    """Fetch proxy list from Webshare API and return list of proxy URLs."""
+    proxies = []
+    if not api_key:
+        logging.warning("WEBSHARE_API_KEY not set. No proxies will be used.")
+        return proxies
+    try:
+        response = requests.get(api_url, headers={"Authorization": api_key})
+        response.raise_for_status()
+        data = response.json()
+        if isinstance(data, dict) and "results" in data:
+            data = data["results"]
+        for proxy in data:
+            if isinstance(proxy, dict) and proxy.get("valid"):
+                ip = proxy.get("proxy_address")
+                port = proxy.get("port")
+                user = proxy.get("username")
+                pwd = proxy.get("password")
+                proxies.append(f"http://{user}:{pwd}@{ip}:{port}")
+    except requests.RequestException as exc:
+        logging.error(f"Erro ao buscar proxies da API: {exc}")
+    return proxies

--- a/trf2/settings.py
+++ b/trf2/settings.py
@@ -7,12 +7,24 @@
 #     https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
 #     https://docs.scrapy.org/en/latest/topics/spider-middleware.html
 
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
 BOT_NAME = "trf2"
 
 SPIDER_MODULES = ["trf2.spiders"]
 NEWSPIDER_MODULE = "trf2.spiders"
 
 ADDONS = {}
+
+# Webshare proxy configuration
+WEBSHARE_API_KEY = os.getenv("WEBSHARE_API_KEY")
+WEBSHARE_PROXY_URL = os.getenv(
+    "WEBSHARE_PROXY_URL",
+    "https://proxy.webshare.io/api/v2/proxy/list/?mode=direct&page=1&page_size=500",
+)
 
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
@@ -62,9 +74,9 @@ LOG_LEVEL = 'INFO' # Pode ser DEBUG para mais detalhes
 
 # Enable or disable downloader middlewares
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
-#DOWNLOADER_MIDDLEWARES = {
-#    "trf2.middlewares.Trf2DownloaderMiddleware": 543,
-#}
+DOWNLOADER_MIDDLEWARES = {
+    "trf2.middlewares.ProxyRotationMiddleware": 610,
+}
 
 # Enable or disable extensions
 # See https://docs.scrapy.org/en/latest/topics/extensions.html


### PR DESCRIPTION
## Summary
- load Webshare credentials from environment
- add utility to fetch proxy list
- rotate proxies on each request via middleware
- document environment settings

## Testing
- `python -m py_compile trf2/proxy_utils.py trf2/middlewares.py trf2/settings.py run_spider.py trf2/db_utils.py trf2/azure_utils.py`
- `pytest -q`
- `scrapy check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685060488d58832e9ab98d597ca56cb8